### PR TITLE
fix #11 pass empty string to strpos() instead of null

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -105,7 +105,7 @@ class CorsService
         // Transform wildcard pattern
         if (!$this->allowAllOrigins) {
             foreach ($this->allowedOrigins as $origin) {
-                if (strpos($origin, '*') !== false) {
+                if (strpos($origin ?? '', '*') !== false) {
                     $this->allowedOriginsPatterns[] = $this->convertWildcardToPattern($origin);
                 }
             }


### PR DESCRIPTION
Fixes:
`strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in vendor/fruitcake/php-cors/src/CorsService.php on line 108`
