### PR TITLE
Add validation for the case where only one origin is allowed.

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -225,7 +225,7 @@ class CorsService
             return false;
         }
 
-        return count($this->allowedOrigins) === 1;
+        return count($this->allowedOrigins) === 1 && in_array($request->headers->get('Origin'), $this->allowedOrigins);
     }
 
     private function configureAllowedMethods(Response $response, Request $request): void


### PR DESCRIPTION
The above because this method only returns the count, but there is no validation between the origin in the header and the allowed origin.