### PR TITLE
Check multiple Vary headers when existing

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -280,9 +280,9 @@ class CorsService
             $varyHeaders = $response->getVary();
             if (!in_array($header, $varyHeaders, true)) {
                 if (count($response->headers->all('Vary')) === 1) {
-                    $response->headers->set('Vary', ((string)$response->headers->get('Vary')) . ', ' . $header);
+                    $response->setVary(((string)$response->headers->get('Vary')) . ', ' . $header);
                 } else {
-                    $response->headers->set('Vary', $header, false);
+                    $response->setVary($header, false);
                 }
             }
         }

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -276,8 +276,15 @@ class CorsService
     {
         if (!$response->headers->has('Vary')) {
             $response->headers->set('Vary', $header);
-        } elseif (!in_array($header, explode(', ', (string) $response->headers->get('Vary')))) {
-            $response->headers->set('Vary', ((string) $response->headers->get('Vary')) . ', ' . $header);
+        } else {
+            $varyHeaders = $response->getVary();
+            if (!in_array($header, $varyHeaders, true)) {
+                if (count($response->headers->all('Vary')) === 1) {
+                    $response->headers->set('Vary', ((string)$response->headers->get('Vary')) . ', ' . $header);
+                } else {
+                    $response->headers->set('Vary', $header, false);
+                }
+            }
         }
 
         return $response;

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -276,6 +276,32 @@ class CorsTest extends TestCase
 
     /**
      * @test
+     * @see http://www.w3.org/TR/cors/index.html#resource-implementation
+     */
+    public function itAppendsMultipleExistingVaryHeaders(): void
+    {
+        $app      = $this->createStackedApp(
+            array(
+                'allowedOrigins' => ['*'],
+                'supportsCredentials' => true,
+            ),
+            array(
+                'Vary' => [
+                    'Content-Type',
+                    'Referer',
+                ],
+            )
+        );
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertCount(3, $response->headers->all('Vary'));
+        $this->assertEquals(['Content-Type', 'Referer', 'Origin'], $response->headers->all('Vary'));
+    }
+
+    /**
+     * @test
      */
     public function itReturnsAccessControlHeadersOnCorsRequest(): void
     {
@@ -555,7 +581,7 @@ class CorsTest extends TestCase
 
     /**
      * @param CorsInputOptions $options
-     * @param string[] $responseHeaders
+     * @param array<array<string>|string> $responseHeaders
      * @return MockApp
      */
     private function createStackedApp(array $options = array(), array $responseHeaders = array()): MockApp

--- a/tests/MockApp.php
+++ b/tests/MockApp.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class MockApp
 {
-    /** @var string[] */
+    /** @var array<array<string>|string> */
     private $responseHeaders;
 
     /**
@@ -30,7 +30,7 @@ class MockApp
     private $cors;
 
     /**
-     * @param string[] $responseHeaders
+     * @param array<array<string>|string> $responseHeaders
      * @param CorsInputOptions $options
      */
     public function __construct(array $responseHeaders, array $options = [])


### PR DESCRIPTION
When multiple Vary headers are set (which is acceptable in HTTP headers), the `->get('Vary')` header only returns the first one. When replacing the headers, this will remove the existing headers.

This checks for all the Vary headers and appends them as a new header when there are > 1 already existing. Otherwise behavior is kept.